### PR TITLE
Fix unresolvable pip dependency conflict in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,8 @@
 # Microsoft Agent Framework — the "foundry" extra brings the Microsoft Foundry
 # client surface (FoundryChatClient, FoundryAgent, Toolbox helpers,
 # FoundryMemoryProvider, FoundryEvals). "devui" provides the local dev server.
-agent-framework==1.2.0
-agent-framework-foundry==1.2.0
+agent-framework==1.13.0
+agent-framework-foundry==1.10.4
 agent-framework-devui
 
 # Azure identity for AzureCliCredential / DefaultAzureCredential
@@ -26,6 +26,6 @@ python-dotenv
 # The A2A extra is currently a PREVIEW build, so it is pinned exactly. It brings
 # agent_framework.a2a (A2AAgent, A2AExecutor); a2a-sdk provides the server app and
 # Agent Card types; uvicorn serves the A2A HTTP application.
-agent-framework-a2a==1.0.0b260424
+agent-framework-a2a==1.0.0b260730
 a2a-sdk
 uvicorn


### PR DESCRIPTION
## Summary
- `pip install -r requirements.txt` currently fails with `ResolutionImpossible` on a fresh install: `agent-framework==1.2.0` pins `agent-framework-core==1.2.0` exactly, but its `[all]` extra pulls in `agent-framework-ag-ui` unpinned. `ag-ui` has since graduated to a stable release (1.0.0/1.0.1) that requires `agent-framework-core>=1.11`, which conflicts with the `1.2.0` pin and can't be resolved without `--pre` (which this file intentionally avoids per its own comment).
- Bumps `agent-framework` (1.2.0 → 1.13.0), `agent-framework-foundry` (1.2.0 → 1.10.4), and `agent-framework-a2a` (`1.0.0b260424` → `1.0.0b260730`) to the latest set of versions that resolve together.

## Test plan
- [x] `pip install --dry-run -r requirements.txt` in a clean venv resolves successfully (previously failed with `ResolutionImpossible`)
- [ ] CI / maintainer sanity check that the pinned versions still match the course's Microsoft Foundry API mapping in `MIGRATION-GUIDE.md`